### PR TITLE
Hinzufügen von Verbindungsmöglichkeiten vis ftp und ftps

### DIFF
--- a/SymconBackup/README.md
+++ b/SymconBackup/README.md
@@ -33,15 +33,18 @@ __Konfigurationsseite__:
 
 Name                      | Beschreibung
 ------------------------- | ------------------
+Verbindungstyp            | Auswahl der Verbindungsart
 Host                      | IP Adresse des Servers
+Port                      | Port auf dem der Client sich auf den Server verbindet. Bei FTPS und FTP ist dies normalerweise 21. Bei SFTP ist dies der Port 22
 Benutzername              | Benutzernamen für die SFTP Verbindung 
 Passwort                  | Passwort für die SFTP Verbindung 
 Modus                     | Modus was für ein Backup erstellt werden soll 
+Zielordner                | Ordner auf dem Server, in dem das Backup erstellt werden soll
 Timer aktivieren          | Aktiviert ein tägliches Update
 Tägliche Zeit zum updaten | Zeit, wann das Update täglich startet  
-Zielordner                | Ordner auf dem Server, in dem das Backup erstellt werden soll
 Expertenoptionen          | Filter um bestimmte Ordner nicht zu übertragen
 Backup erstellen          | Button, welcher sofort ein Update startet. 
+Verbindung testen         | Testet, ob eine Verbindung hergestellt werden kann
 
 __Modus__: 
 Vollständiges Backup: Erstellt eine vollständige Kopie in einem seperaten Ordner 

--- a/SymconBackup/README.md
+++ b/SymconBackup/README.md
@@ -1,5 +1,5 @@
 # SymconBackup
-Erstellt ein Backup über SFTP.
+Erstellt ein Backup über SFTP, FTP oder FTPS.
 
 ### Inhaltsverzeichnis
 
@@ -12,8 +12,8 @@ Erstellt ein Backup über SFTP.
 
 ### 1. Funktionsumfang
 
-* Erstell ein Backup über SFTP auf einem Server
-* Updatet ein Backup über SFTP auf einem Server
+* Erstell ein Backup über SFTP, FTP oder FTPS auf einem Server
+* Updatet ein Backup über SFTP, FTP oder FTPS auf einem Server
 
 ### 2. Voraussetzungen
 
@@ -56,8 +56,8 @@ Die Statusvariablen/Kategorien werden automatisch angelegt. Das Löschen einzeln
 
 #### Statusvariablen
 
-Name             | Typ            | Beschreibung
----------------- | -------------- | ------------
+Name                           | Typ     | Beschreibung
+------------------------------ | ------- | ------------
 Zuletzt abgeschlossenes Backup | Integer | Zeitpunkt, zudem das letzte Backup abgeschlossen wurde
 Übertragene Megabytes          | Float   | Megabytes, welche beim letzten Update übertragen wurde 
 

--- a/SymconBackup/form.json
+++ b/SymconBackup/form.json
@@ -94,7 +94,6 @@
             "items": [
                 {
                     "type": "NumberSpinner",
-                    
                     "minimum": 1,
                     "name": "SizeLimit",
                     "caption": "Size Limit",

--- a/SymconBackup/form.json
+++ b/SymconBackup/form.json
@@ -21,7 +21,7 @@
                             "value": "FTPS"
                         }
                     ],
-                    "onChange": "SB_UIChangePort($id, $ConnectionType);" 
+                    "onChange": "SB_UIChangePort($id, $ConnectionType);"
                 },
                 {
                     "type": "ValidationTextBox",
@@ -128,7 +128,7 @@
         },
         {
             "type": "Button",
-            "caption": "TestConnection",
+            "caption": "Test Connection",
             "onClick": "SB_UITestConnection($id);"
         }
     ],
@@ -142,6 +142,11 @@
             "code": 202,
             "icon": "error",
             "caption": "Target Directory is invalid"
+        },
+        {
+            "code": 203,
+            "icon": "error",
+            "caption": "Host/Port is invalid"
         }
     ]
 }

--- a/SymconBackup/form.json
+++ b/SymconBackup/form.json
@@ -4,10 +4,41 @@
             "type": "RowLayout",
             "items": [
                 {
+                    "type": "Select",
+                    "caption": "Connection Type",
+                    "name": "ConnectionType",
+                    "options": [
+                        {
+                            "caption": "SFTP",
+                            "value": "SFTP"
+                        },
+                        {
+                            "caption": "FTP",
+                            "value": "FTP"
+                        },
+                        {
+                            "caption": "FTPS",
+                            "value": "FTPS"
+                        }
+                    ],
+                    "onChange": "SB_UIChangePort($id, $ConnectionType);" 
+                },
+                {
                     "type": "ValidationTextBox",
                     "name": "Host",
                     "caption": "Host"
                 },
+                {
+                    "type": "NumberSpinner",
+                    "name": "Port",
+                    "caption": "Port",
+                    "minimum": 0
+                }
+            ]
+        },
+        {
+            "type": "RowLayout",
+            "items": [
                 {
                     "type": "ValidationTextBox",
                     "name": "Username",

--- a/SymconBackup/form.json
+++ b/SymconBackup/form.json
@@ -93,6 +93,14 @@
             "caption": "Expert options",
             "items": [
                 {
+                    "type": "NumberSpinner",
+                    
+                    "minimum": 1,
+                    "name": "SizeLimit",
+                    "caption": "Size Limit",
+                    "suffix": "MB"
+                },
+                {
                     "type": "List",
                     "name": "FilterDirectory",
                     "caption": "Filter Directory",

--- a/SymconBackup/form.json
+++ b/SymconBackup/form.json
@@ -125,6 +125,11 @@
             "type": "Button",
             "caption": "Create Backup",
             "onClick": "SB_CreateBackup($id);"
+        },
+        {
+            "type": "Button",
+            "caption": "TestConnection",
+            "onClick": "SB_UITestConnection($id);"
         }
     ],
     "status": [

--- a/SymconBackup/locale.json
+++ b/SymconBackup/locale.json
@@ -1,24 +1,30 @@
 {
     "translations": {
         "de": {
-            "Target Direction is invalid": "Zielpfad ist nicht korrekt",
-            "Username/Password is invalid": "Benutzername/Passwort ist nicht korrekt",
-            "Target Directory": "Zielordner",
-            "Password": "Passwort",
+            "Connection Type": "Verbindungstype",
             "Username": "Benutzername",
-            "Full Backup": "Vollständiges Backup",
-            "Update Backup": "Backup updaten",
+            "Password": "Passwort",
             "Mode": "Modus",
-            "Create Backup": "Backup erstellen",
+            "Full Backup": "Vollständiges Backup",
+            "Incremental Backup": "Inkrementelles Backup",
+            "Target Directory": "Zielordner",
+            "Enable Timer": "Timer aktivieren",
             "Daily Update Time": "Tägliche Zeit zum Updaten",
+            "Expert options": "Expertenoptionen",
             "Filter Directory": "Gefilterte Ordner",
             "Directory": "Ordner",
-            "Incremental Backup": "Inkrementelles Backup",
-            "An other Backup is already running": "Ein anderes Backup wird bereits erstellt",
-            "Enable Timer": "Timer aktivieren",
-            "Expert options": "Expertenoptionen",
+            "Test Connection": "Verbindung testen",
+            "Create Backup": "Backup erstellen",
             "Last Finished Backup": "Zuletzt abgeschlossenes Backup",
-            "Transferred Megabytes": "Übertragene Megabytes"
+            "Transferred Megabytes": "Übertragene Megabytes",
+            "Wait on connection": "Auf Verbindung warten",
+            "An other Backup is already running": "Ein anderes Backup wird bereits erstellt",
+            "The Connection Type is undefine": "Der Verbindungstyp ist nicht definiert",
+            "Connection is valid": "Die Verbindung ist korrekt",
+            "Target Direction is invalid": "Zielpfad ist nicht korrekt",
+            "Username/Password is invalid": "Benutzername/Passwort ist nicht korrekt",
+            "Connection is invalid": "Verbindung ist nicht korrekt",
+            "Error: The Connection is invalid": "Fehler: Die Verbindung ist nicht korrekt"
         }
     }
 }

--- a/SymconBackup/module.json
+++ b/SymconBackup/module.json
@@ -8,5 +8,5 @@
     "childRequirements": [],
     "implemented": [],
     "prefix": "SB",
-    "url": "https://www.symcon.de"
+    "url": "https://github.com/symcon/SymconBackup"
 }

--- a/SymconBackup/module.php
+++ b/SymconBackup/module.php
@@ -60,27 +60,8 @@ class SymconBackup extends IPSModule
     {
         if (IPS_SemaphoreEnter('CreateBackup', 1000)) {
             //Create Connection
-            $username = $this->ReadPropertyString('Username');
-            $password = $this->ReadPropertyString('Password');
-            $host = $this->ReadPropertyString('Host');
-            $port = $this->ReadPropertyInteger('Port');
-            switch ($this->ReadPropertyString('ConnectionType')) {
-                case 'SFTP':
-                    $connection = new SFTP($host, $port);
-                    break;
-                case 'FTP':
-                    $connection = new FTP($host, $port);
-                    break;
-                case 'FTPS':
-                    $connection = new FTPS($host, $port);
-                    break;
-                default:
-                    echo $this->Translate('The Connection Type is undefine');
-                    $this->SetStatus(201);
-                    break;
-            }
-            if (!$connection->login($username, $password)) {
-                $this->SetStatus(201);
+            $connection = $this->createConnection();
+            if ($connection === false) {
                 IPS_SemaphoreLeave('CreateBackup');
                 return false;
             }
@@ -175,41 +156,8 @@ class SymconBackup extends IPSModule
 
     public function UITestConnection()
     {
-        //Create Connection
-        $username = $this->ReadPropertyString('Username');
-        $password = $this->ReadPropertyString('Password');
-        $host = $this->ReadPropertyString('Host');
-        $port = $this->ReadPropertyInteger('Port');
-        $this->UpdateFormField('Progress', 'visible', true);
-        $this->UpdateFormField('Progress', 'caption', $this->Translate('Wait on connection'));
-        try {
-            switch ($this->ReadPropertyString('ConnectionType')) {
-                case 'SFTP':
-                    $connection = new SFTP($host, $port);
-                    break;
-                case 'FTP':
-                    $connection = new FTP($host, $port);
-                    break;
-                case 'FTPS':
-                    $connection = new FTPS($host, $port);
-                    break;
-                default:
-                    echo $this->Translate('The Connection Type is undefine');
-                    $this->SetStatus(201);
-                    break;
-            }
-        } catch (\Throwable $th) {
-            //Throw than the initial of FTP or FTPS connection failed
-            $this->UpdateFormField('Progress', 'caption', $this->Translate($th->getMessage()));
-            echo $this->Translate($th->getMessage());
-            $this->SetStatus(203);
-            return false;
-        }
-        if ($connection->login($username, $password) === false) {
-            echo $this->Translate('Connection is invalid.') . "\n" . $this->Translate('Username/Password is invalid');
-            $this->SetStatus(201);
-            return false;
-        } else {
+        $connection = $this->createConnection();
+        if($connection !== false){
             echo $this->Translate('Connection is valid');
             $connection->disconnect();
             $this->UpdateFormField('Progress', 'visible', false);
@@ -380,5 +328,45 @@ class SymconBackup extends IPSModule
             }
         }
         return false;
+    }
+
+    private function createConnection()
+    {
+        //Create Connection
+        $username = $this->ReadPropertyString('Username');
+        $password = $this->ReadPropertyString('Password');
+        $host = $this->ReadPropertyString('Host');
+        $port = $this->ReadPropertyInteger('Port');
+        $this->UpdateFormField('Progress', 'visible', true);
+        $this->UpdateFormField('Progress', 'caption', $this->Translate('Wait on connection'));
+        try {
+            switch ($this->ReadPropertyString('ConnectionType')) {
+                case 'SFTP':
+                    $connection = new SFTP($host, $port);
+                    break;
+                case 'FTP':
+                    $connection = new FTP($host, $port);
+                    break;
+                case 'FTPS':
+                    $connection = new FTPS($host, $port);
+                    break;
+                default:
+                    echo $this->Translate('The Connection Type is undefine');
+                    $this->SetStatus(201);
+                    break;
+            }
+        } catch (\Throwable $th) {
+            //Throw than the initial of FTP or FTPS connection failed
+            $this->UpdateFormField('Progress', 'caption', $this->Translate($th->getMessage()));
+            echo $this->Translate($th->getMessage());
+            $this->SetStatus(203);
+            return false;
+        }
+        if ($connection->login($username, $password) === false) {
+            echo $this->Translate('Connection is invalid.') . "\n" . $this->Translate('Username/Password is invalid');
+            $this->SetStatus(201);
+            return false;
+        }
+        return $connection;
     }
 }

--- a/SymconBackup/module.php
+++ b/SymconBackup/module.php
@@ -12,7 +12,9 @@ class SymconBackup extends IPSModule
         //Never delete this line!
         parent::Create();
 
+        $this->RegisterPropertyString('ConnectionType', 'SFTP');
         $this->RegisterPropertyString('Host', '');
+        $this->RegisterPropertyInteger('Port', 22);
         $this->RegisterPropertyString('Username', '');
         $this->RegisterPropertyString('Password', '');
 
@@ -119,10 +121,29 @@ class SymconBackup extends IPSModule
         $this->UpdateFormField('DailyUpdateTime', 'visible', $value);
     }
 
+    public function UIChangePort(string $value)
+    {
+        if ($this->ReadPropertyInteger('Port') == 21 || $this->ReadPropertyInteger('Port') == 22) {
+            switch ($value) {
+                case 'SFTP':
+                    $value = 22;
+                    break;
+                case 'FTP':
+                case 'FTPS':
+                    $value = 21;
+                    break;
+                default:
+                    # code...
+                    break;
+            }
+            $this->UpdateFormField('Port', 'value', $value);
+        }
+    }
+
     public function GetConfigurationForm()
     {
         $json = json_decode(file_get_contents(__DIR__ . '/form.json', true), true);
-        $json['elements'][3]['visible'] = $this->ReadPropertyBoolean('EnableTimer');
+        $json['elements'][4]['visible'] = $this->ReadPropertyBoolean('EnableTimer');
 
         return json_encode($json);
     }

--- a/SymconBackup/module.php
+++ b/SymconBackup/module.php
@@ -165,7 +165,7 @@ class SymconBackup extends IPSModule
         }
     }
 
-    private function copyLocalToRemote(string $dir, $connection, string $mode, &$transferred)
+    private function copyLocalToRemote(string $dir, $connection, string $mode, & $transferred)
     {
 
         //get the local files

--- a/SymconBackup/module.php
+++ b/SymconBackup/module.php
@@ -244,7 +244,7 @@ class SymconBackup extends IPSModule
                 if ($filesize > $this->ReadPropertyInteger('SizeLimit') * 1024 * 1024) {
                     $this->SendDebug('Index', sprintf('Skipping too big file... %s. Size: %s', $dir . '/' . $file, $this->formatBytes($filesize)), 0);
                 }
-                
+
                 switch ($mode) {
                     case 'FullBackup':
                         try {

--- a/SymconBackup/module.php
+++ b/SymconBackup/module.php
@@ -157,7 +157,7 @@ class SymconBackup extends IPSModule
     public function UITestConnection()
     {
         $connection = $this->createConnection();
-        if($connection !== false){
+        if ($connection !== false) {
             echo $this->Translate('Connection is valid');
             $connection->disconnect();
             $this->UpdateFormField('Progress', 'visible', false);

--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
     "id": "{FBD18A58-72C5-A1B9-D942-46CBB27C6174}",
     "name": "SymconBackup",
     "author": "Symcon GmbH",
-    "url": "https://www.symcon.de",
+    "url": "https://github.com/symcon/SymconBackup",
     "compatibility": {
         "version": "6.3"
     },

--- a/libs/FTP.php
+++ b/libs/FTP.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+class FTP
+{
+    public $connection;
+
+    public function __construct($host, $port)
+    {
+        $this->connection = ftp_connect($host, $port);
+        return $this->connection;
+    }
+
+    public function chdir(string $dir): bool
+    {
+        return ftp_chdir($this->connection, $dir);
+    }
+
+    public function rawlist(string $dir = '.'): mixed
+    {
+        return ftp_rawlist($this->connection, $dir);
+    }
+
+    public function delete(string $path): bool
+    {
+        return ftp_delete($this->connection, $path);
+    }
+
+    public function is_dir(string $path): bool
+    {
+        if(@ftp_chdir($this->connection,$dir)) { 
+            ftp_cdup($this->connection); 
+            return true; 
+        } else { 
+            return false; 
+        } 
+    }
+
+    public function pwd()
+    {
+        return ftp_pwd($this->connection); 
+    }
+
+    public function mkdir(string $dir)
+    {
+        return ftp_mkdir($this->connection, $dir);
+    }
+
+    public function put(string $remote_file, string $data): bool
+    {
+        return ftp_put($this->connection, $remote_file, $data);
+    }
+
+    public function filesize(string $path)
+    {
+        return ftp_size($this->connection, $path);
+    }
+
+    public function filemtime(string $path)
+    {
+        return ftp_mdtm($this->connection, $path);
+    }
+
+    public function login(string $username, string $password)
+    {
+        return ftp_login($this->connection, $username, $password);
+    }
+
+    public function disconnect()
+    {
+        return ftp_close($this->connection);
+    }
+}

--- a/libs/FTP.php
+++ b/libs/FTP.php
@@ -16,17 +16,29 @@ class FTP
 
     public function chdir(string $dir): bool
     {
-        return ftp_chdir($this->connection, $dir);
+        $result = @ftp_chdir($this->connection, $dir);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function rawlist(string $dir = '.'): mixed
     {
-        return ftp_rawlist($this->connection, $dir);
+        $result = @ftp_rawlist($this->connection, $dir);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function delete(string $path): bool
     {
-        return ftp_delete($this->connection, $path);
+        $result = @ftp_delete($this->connection, $path);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function is_dir(string $path): bool
@@ -42,36 +54,64 @@ class FTP
 
     public function pwd()
     {
-        return ftp_pwd($this->connection);
+        $result = @ftp_pwd($this->connection);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function mkdir(string $dir)
     {
-        return ftp_mkdir($this->connection, $dir);
+        $result = @ftp_mkdir($this->connection, $dir);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function put(string $remote_file, string $data): bool
     {
-        return ftp_put($this->connection, $remote_file, $data);
+        $result = @ftp_put($this->connection, $remote_file, $data);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function filesize(string $path)
     {
-        return ftp_size($this->connection, $path);
+        $result = @ftp_size($this->connection, $path);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function filemtime(string $path)
     {
-        return ftp_mdtm($this->connection, $path);
+        $result = @ftp_mdtm($this->connection, $path);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function login(string $username, string $password)
     {
-        return ftp_login($this->connection, $username, $password);
+        $result = @ftp_login($this->connection, $username, $password);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 
     public function disconnect()
     {
-        return ftp_close($this->connection);
+        $result = @ftp_close($this->connection);
+        if ($result === false) {
+            throw new Exception(error_get_last()['message']);
+        }
+        return $result;
     }
 }

--- a/libs/FTP.php
+++ b/libs/FTP.php
@@ -9,7 +9,9 @@ class FTP
     public function __construct($host, $port)
     {
         $this->connection = ftp_connect($host, $port);
-        return $this->connection;
+        if (!$this->connection) {
+            throw new ErrorException('Error: Host/Port is invalid', 10060);
+        }
     }
 
     public function chdir(string $dir): bool
@@ -29,17 +31,18 @@ class FTP
 
     public function is_dir(string $path): bool
     {
-        if(@ftp_chdir($this->connection,$dir)) { 
-            ftp_cdup($this->connection); 
-            return true; 
-        } else { 
-            return false; 
-        } 
+        //Found there: https://gist.github.com/Dare-NZ/5523650#file-is_dir-php-L37
+        if (@ftp_chdir($this->connection, $dir)) {
+            ftp_cdup($this->connection);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public function pwd()
     {
-        return ftp_pwd($this->connection); 
+        return ftp_pwd($this->connection);
     }
 
     public function mkdir(string $dir)

--- a/libs/FTPS.php
+++ b/libs/FTPS.php
@@ -9,6 +9,8 @@ class FTPS extends FTP
     public function __construct($host, $port)
     {
         $this->connection = ftp_ssl_connect($host, $port);
-        return $this->connection;
+        if (!$this->connection) {
+            throw new ErrorException('Error: Host/Port is invalid', 10060);
+        }
     }
 }

--- a/libs/FTPS.php
+++ b/libs/FTPS.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class FTPS extends FTP
+{
+    public $connection;
+
+    public function __construct($host, $port)
+    {
+        $this->connection = ftp_ssl_connect($host, $port);
+        return $this->connection;
+    }
+}


### PR DESCRIPTION
Die Verbindungsmöglichkeiten FTP und FTPS wurden hinzugefügt. 
Genauso wie ein Button mit dem man die Verbindung mit den momentanen Host, Username und Password testen kann.

Was noch fehlt: 
- [x] Popup Dialog mit dem man zum Zielordner browsen kann  -> siehe https://github.com/symcon/SymconBackup/pull/2
- [x] Größenlimit
- [x] Übersetzung, Dokumentation
- [x] Abfangen von Fehlerhaften Einträgen 