### PR TITLE
Änderung zu konsistenten Ordnernamen

### DIFF
--- a/Backup/README.md
+++ b/Backup/README.md
@@ -51,9 +51,14 @@ Backup erstellen                | Button, welcher sofort ein Update startet.
 Verbindung testen               | Testet, ob eine Verbindung hergestellt werden kann
 
 __Modus__: 
-Vollständiges Backup: Erstellt eine vollständige Kopie in einem separaten Ordner 
-Inkrementelles Backup: Updatet ein bestehendes Backup. Im Zielordner wird der Ordner 'symcon' zusätzlich angelegt. 
-Steht die Option 'Wechsel nach Ordner' nicht auf 'Niemals', so wird der Ordner nach der eingestellten Zeit gewechselt. 
+Vollständiges Backup: Erstellt eine vollständige Kopie in einem separaten Ordner nach dem Pattern: symcon-backup-{Jahr}-{Monat}-{Tag}-{Stunde}-{Minute}-{Sekunde}  
+Inkrementelles Backup: Updatet ein bestehendes Backup.  
+Steht die Option 'Wechsel nach Ordner' nicht auf 'Niemals', so wird der Ordner nach der eingestellten Zeit gewechselt.  
+Die Ordner, welche beim inkrementellen Backup erstellt werden, folgen folgenden Pattern:  
+- Niemals: symcon-backup
+- Woche: symcon-backup-{Jahr}-0{Kalenderwoche}  
+- Monat: symcon-backup-{Jahr}-{Monat}  
+- Jahr: symcon-backup-{Jahr}  
 
 ### 5. Statusvariablen und Profile
 

--- a/Backup/module.php
+++ b/Backup/module.php
@@ -117,7 +117,7 @@ class Backup extends IPSModule
             //Set the remote dir
             $mode = $this->ReadPropertyString('Mode');
             if ($mode == 'FullBackup') {
-                $backupName = date('Y-m-d-H-i-s');
+                $backupName = 'symcon-backup-' . date('Y-m-d-H-i-s');
                 $connection->mkdir($backupName);
                 $connection->chdir($backupName);
             } else {
@@ -130,32 +130,30 @@ class Backup extends IPSModule
                     $connection->chdir($dir);
                 };
 
-                $checkDir('symcon');
+                $currentPattern = 'symcon-backup';
                 //if monthly or yearly check if an dir for this period is exist or create it
                 switch ($this->ReadPropertyString('ChangePeriode')) {
                     case 'Weekly':
                         //check if the current week had a dir if not create one
-                        //Pattern 'Y-m-d' check if it is a Monday
-                        $currentPattern = date('Y-m-d') == date('Y-m-d', strtotime('Monday')) ? date('Y-m-d') : date('Y-m-d', strtotime('Monday'));
-                        $checkDir($currentPattern);
+                        //Pattern 'Y-0W'
+                        $currentPattern .= '-' . date('Y-0W');
                         break;
                     case 'Monthly':
                         //check if the current month had a dir if not create one
                         // Pattern 'Y'-'m'
-                        $currentPattern = date('Y-m');
-                        $checkDir($currentPattern);
+                        $currentPattern .= '-' . date('Y-m');
                         break;
                     case 'Yearly':
                         //check if the current year had a dir if not create one
                         //pattern 'Y'
-                        $currentPattern = date('Y');
-                        $checkDir($currentPattern);
+                        $currentPattern .= '-' . date('Y');
                         break;
                     case 'Never':
                     default:
-                        //On never and default create the Backup in the symcon folder
+                        //On never and default create the Backup in the symcon-backup folder
                         break;
                 }
+                $checkDir($currentPattern);
             }
 
             //Get the total number of the files to copy


### PR DESCRIPTION
Änderung der Ordnernamen, sodass es konsistenter ist. 

Vollständiges Backup: symcon-backup-{Jahr}-{Monat}-{Tag}-{Stunde}-{Minute}-{Sekunde}  

Inkrementelles Backup: 

- Niemals: symcon-backup
- Woche: symcon-backup-{Jahr}-0{Kalenderwoche}  
- Monat: symcon-backup-{Jahr}-{Monat}  
- Jahr: symcon-backup-{Jahr}  

close https://github.com/symcon/modules/issues/248